### PR TITLE
Sort JSON array before calculating hashes.

### DIFF
--- a/src/ETL/Load/Load.php
+++ b/src/ETL/Load/Load.php
@@ -55,7 +55,7 @@ abstract class Load
      *
      * @see \Harvest\Harvester
      */
-    private function itemState($item): int
+    protected function itemState($item): int
     {
         if (isset($item->identifier)) {
             // Load the hash from storage, for comparison, if it exists.

--- a/src/Util.php
+++ b/src/Util.php
@@ -4,11 +4,46 @@ namespace Harvest;
 
 class Util
 {
+
+    /**
+     * Generate a hash of a data structure.
+     *
+     * @param mixed $item
+     *   The data structure to hash.
+     *
+     * @return string
+     *   Hash of the serialized data structure.
+     */
     public static function generateHash($item): string
+    {
+        // Encode as JSON and then decode as associative arrays.
+        // @todo Is this the most efficient way to convert an arbitrary
+        //   data structure into an array?
+        $decoded = json_decode(
+            json_encode($item, JSON_THROW_ON_ERROR),
+            true
+        );
+        // Sort the array by keys.
+        static::recursiveKeySort($decoded);
+        return hash('sha256', serialize($decoded));
+    }
+
+    /**
+     * Legacy hash generation.
+     *
+     * We use this for a secondary comparison, if generateHash() says they
+     * don't match.
+     *
+     * @param mixed $item
+     *   The data structure to hash.
+     *
+     * @return string
+     *   Hash of the serialized data structure.
+     */
+    public static function legacyGenerateHash($item): string
     {
         return hash('sha256', serialize($item));
     }
-
 
     public static function getDatasetId($dataset): string
     {
@@ -23,5 +58,27 @@ class Util
             $id = $dataset->identifier;
         }
         return "{$id}";
+    }
+
+    /**
+     * Sort an array in place by key.
+     *
+     * Recursively applies ksort() to any value in the array that is an array.
+     *
+     * @param $array
+     *   The array to be sorted.
+     * @param $flags
+     *   Flags to pass along to ksort().
+     *
+     * @see \ksort()
+     */
+    public static function recursiveKeySort(&$array, int $flags = SORT_REGULAR): void
+    {
+        foreach ($array as &$value) {
+            if (is_array($value)) {
+                static::recursiveKeySort($value);
+            }
+        }
+        ksort($array, $flags);
     }
 }

--- a/test/ETL/Load/LoadTest.php
+++ b/test/ETL/Load/LoadTest.php
@@ -73,7 +73,7 @@ class LoadTest extends TestCase
     /**
      * @covers ::itemState
      */
-    public function testItemStateException()
+    public function testItemStateException(): void
     {
         // The itemState() method should throw an exception if the item does
         // not have an identifier. This should make its way back through run()

--- a/test/ETL/Load/LoadTest.php
+++ b/test/ETL/Load/LoadTest.php
@@ -58,7 +58,7 @@ class LoadTest extends TestCase
             ])
             ->getMockForAbstractClass();
 
-        // Finally assert that our data has the correct hash. You can make this
+        // Finally assert that our data has a matching hash. You can make this
         // test fail by changing the 'something' => 'else' data, resulting in
         // a different hash.
         $this->assertEquals(

--- a/test/ETL/Load/LoadTest.php
+++ b/test/ETL/Load/LoadTest.php
@@ -69,4 +69,22 @@ class LoadTest extends TestCase
             ])
         );
     }
+
+    /**
+     * @covers ::itemState
+     */
+    public function testItemStateException()
+    {
+        // The itemState() method should throw an exception if the item does
+        // not have an identifier. This should make its way back through run()
+        // to the caller.
+        $load = $this->getMockBuilder(Load::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Item does not have an identifier');
+
+        $load->run((object) ['no_identifier' => '']);
+    }
 }

--- a/test/ETL/Load/LoadTest.php
+++ b/test/ETL/Load/LoadTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace HarvestTest\ETL\Load;
+
+use Contracts\RetrieverInterface;
+use Harvest\ETL\Load\Load;
+use Harvest\Harvester;
+use Harvest\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Harvest\ETL\Load\Load
+ * @coversDefaultClass \Harvest\ETL\Load\Load
+ *
+ * @group harvest
+ */
+class LoadTest extends TestCase
+{
+
+    public static function provideUnchangedHash(): array
+    {
+        return [
+            'legacy' => ['918dae0183618b5a4c0da7cd0ca82a61a95c7d03c4822c2f46e4c34be43f7f65'],
+            'not_legacy' => ['6474af9ec864832917578b9a0e1824315cb98b907e66824ea06e1ce193fe3c0a'],
+        ];
+    }
+
+    /**
+     * @covers ::itemState
+     * @dataProvider provideUnchangedHash
+     */
+    public function testLoadUnchanged(string $hash): void
+    {
+        $identifier = 'test_id';
+
+        // Mock up a hash storage to give us back a hash that will match,
+        // either as a legacy hash or a non-legacy one, depending on the
+        // data provider.
+        $hash_storage = $this->getMockBuilder(RetrieverInterface::class)
+            ->onlyMethods(['retrieve'])
+            ->getMockForAbstractClass();
+        $hash_storage->expects($this->once())
+            ->method('retrieve')
+            ->with($identifier)
+            // Mock up our hash object.
+            ->willReturn(json_encode((object) [
+                'identifier' => $identifier,
+                'hash' => $hash,
+            ]));
+
+        // Mock up a loader that has run() and itemState() so we can test. Pass
+        // along our mocked hash storage to the constructor.
+        $load = $this->getMockBuilder(Load::class)
+            ->setConstructorArgs([
+                $this->createStub(StorageInterface::class),
+                $hash_storage,
+                $this->createStub(StorageInterface::class)
+            ])
+            ->getMockForAbstractClass();
+
+        // Finally assert that our data has the correct hash. You can make this
+        // test fail by changing the 'something' => 'else' data, resulting in
+        // a different hash.
+        $this->assertEquals(
+            Harvester::HARVEST_LOAD_UNCHANGED,
+            $load->run((object) [
+                'identifier' => $identifier,
+                'something' => 'else',
+            ])
+        );
+    }
+}

--- a/test/UtilTest.php
+++ b/test/UtilTest.php
@@ -5,6 +5,12 @@ namespace HarvestTest;
 use PHPUnit\Framework\TestCase;
 use Harvest\Util;
 
+/**
+ * @covers \Harvest\Util
+ * @coversDefaultClass \Harvest\Util
+ *
+ * @group harvest
+ */
 class UtilTest extends TestCase
 {
     public function test(): void
@@ -12,5 +18,70 @@ class UtilTest extends TestCase
         $fake_dataset = "Not an object";
         $this->expectExceptionMessage("The dataset " . json_encode($fake_dataset) . " is not an object.");
         Util::getDatasetId($fake_dataset);
+    }
+
+    public static function provideJsonSame(): array
+    {
+        return [
+            'same_shallow_values' => [
+                (object) ["key_a" => "value", "key_b" => "value"],
+                (object) ["key_b" => "value", "key_a"=> "value"],
+            ],
+            'same_deep_values' => [
+                ["key_a" => "value", "key_b" => ["deep_1" => "value1", "deep_2" => "value2"]],
+                ["key_b" => ["deep_2" => "value2", "deep_1" => "value1"], "key_a"=> "value"],
+            ],
+        ];
+    }
+
+    /**
+     * @covers ::generateHash
+     * @dataProvider provideJsonSame
+     */
+    public function testJsonHashSame($first, $second): void
+    {
+        $this->assertEquals(
+            Util::generateHash($first),
+            Util::generateHash($second)
+        );
+    }
+
+
+    public static function provideArrays(): array
+    {
+        return [
+            'fully_flipped' => [
+                [
+                    'a' => [
+                        'A' => '2',
+                        'B' => '2',
+                    ],
+                    'z' => [
+                        'Y' => '1',
+                        'Z' => '1',
+                    ],
+                ],
+                [
+                    'z' => [
+                        'Z' => '1',
+                        'Y' => '1',
+                    ],
+                    'a' => [
+                        'B' => '2',
+                        'A' => '2',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @covers ::recursiveKeySort
+     * @dataProvider provideArrays
+     */
+    public function testRecursiveKSort(array $expected_array, array $array): void
+    {
+        Util::recursiveKeySort($array);
+        $this->assertSame($expected_array, $array);
     }
 }

--- a/test/UtilTest.php
+++ b/test/UtilTest.php
@@ -15,8 +15,8 @@ class UtilTest extends TestCase
 {
     public function test(): void
     {
-        $fake_dataset = "Not an object";
-        $this->expectExceptionMessage("The dataset " . json_encode($fake_dataset) . " is not an object.");
+        $fake_dataset = 'Not an object';
+        $this->expectExceptionMessage('The dataset ' . json_encode($fake_dataset) . ' is not an object.');
         Util::getDatasetId($fake_dataset);
     }
 
@@ -24,12 +24,12 @@ class UtilTest extends TestCase
     {
         return [
             'same_shallow_values' => [
-                (object) ["key_a" => "value", "key_b" => "value"],
-                (object) ["key_b" => "value", "key_a"=> "value"],
+                (object) ['key_a' => 'value', 'key_b' => 'value'],
+                (object) ['key_b' => 'value', 'key_a'=> 'value'],
             ],
             'same_deep_values' => [
-                ["key_a" => "value", "key_b" => ["deep_1" => "value1", "deep_2" => "value2"]],
-                ["key_b" => ["deep_2" => "value2", "deep_1" => "value1"], "key_a"=> "value"],
+                ['key_a' => 'value', 'key_b' => ['deep_1' => 'value1', 'deep_2' => 'value2']],
+                ['key_b' => ['deep_2' => 'value2', 'deep_1' => 'value1'], 'key_a'=> 'value'],
             ],
         ];
     }


### PR DESCRIPTION
- Modifies `\Harvest\Util` to be able to sort deep arrays and to calculate the hash based on the sorted array.
- Keeps the old hash computation as `legacyGenerateHash()` so that older data can still be valid.
- Modifies `\Harvest\ETL\Load\Load` to check the legacy hash if the new one doesn't match. Loaders in getdkan/harvest and within DKAN use this as a base class so it should work with DKAN.
- Adds tests to make sure this all works.